### PR TITLE
fix "Invalid argument type"?

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export class RedisStore {
         const pipeline = this.client.multi();
         for (const update of updates) {
             if (update.id) {
-                pipeline.hSet(this.key('groups', update.id), update as unknown as Record<string, string>);
+                pipeline.set(this.key('groups', update.id), JSON.stringify(update));
             }
         }
         await pipeline.exec();


### PR DESCRIPTION
i don't know if this only happens to me, but i get this error when a group update comes up:

```bash
TypeError: Invalid argument type
    at encodeCommand (E:\node-projects\neru-wa\node_modules\@redis\client\dist\lib\client\RESP2\encoder.js:17:19)
    at RedisCommandsQueue.getCommandToSend (E:\node-projects\neru-wa\node_modules\@redis\client\dist\lib\client\commands-queue.js:138:45)
    at Commander._RedisClient_tick (E:\node-projects\neru-wa\node_modules\@redis\client\dist\lib\client\index.js:545:76)
    at Commander.multiExecutor (E:\node-projects\neru-wa\node_modules\@redis\client\dist\lib\client\index.js:292:86)
    at Commander.exec (E:\node-projects\neru-wa\node_modules\@redis\client\dist\lib\client\multi-command.js:81:175)
    at RedisStore.<anonymous> (E:\node-projects\neru-wa\node_modules\baileys-redis-store\dist\js\index.js:159:28)
    at Generator.next (<anonymous>)
    at E:\node-projects\neru-wa\node_modules\baileys-redis-store\dist\js\index.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (E:\node-projects\neru-wa\node_modules\baileys-redis-store\dist\js\index.js:4:12)
    at RedisStore.handleGroupsUpdate (E:\node-projects\neru-wa\node_modules\baileys-redis-store\dist\js\index.js:152:16)
    at EventEmitter.emit (node:events:531:35)
    at EventEmitter.<anonymous> (E:\node-projects\neru-wa\node_modules\baileys\lib\Utils\event-buffer.js:40:16)
    at EventEmitter.emit (node:events:519:28)
    at Object.emit (E:\node-projects\neru-wa\node_modules\baileys\lib\Utils\event-buffer.js:94:23)
    at Object.groupFetchAllParticipating (E:\node-projects\neru-wa\node_modules\baileys\lib\Socket\groups.js:57:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Client._update (E:\node-projects\neru-wa\src\client\Client.js:179:28)

Node.js v20.16.0
```

What i saw is that `hSet` needs three arguments: `key`, `field`, `value`, `field` is not provided, as `update` is supposed to be the value.
I saw that other events use `hSet` the same way, but they don't throw any error, so i don't fully understand this. Feel free to correct me if i'm wrong on something btw!  